### PR TITLE
Makes base-select scroll more obvious

### DIFF
--- a/components/global/base_select/BaseSelect.vue
+++ b/components/global/base_select/BaseSelect.vue
@@ -214,7 +214,7 @@ export default {
 
 <style scoped>
 .base-select-options {
-  max-height: 250px;
+  max-height: 260px;
 }
 
 .base-select-spacer {


### PR DESCRIPTION
Extends the height of the base-select by 10px to make it more obvious when more options are available via scroll

Before:

<img width="885" alt="Screenshot 2020-10-22 at 12 39 20" src="https://user-images.githubusercontent.com/14224459/96861620-9db37100-1464-11eb-965f-9b379e0fc6dd.png">

After:

<img width="860" alt="Screenshot 2020-10-22 at 12 40 07" src="https://user-images.githubusercontent.com/14224459/96861635-a1df8e80-1464-11eb-80b2-269fea286e8a.png">
